### PR TITLE
RESTEasy clientfactory: allow tuning async pool request queue size

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/client/src/main/java/com/opentable/jaxrs/JaxRsClientConfig.java
+++ b/client/src/main/java/com/opentable/jaxrs/JaxRsClientConfig.java
@@ -58,6 +58,15 @@ public interface JaxRsClientConfig
     }
 
     /**
+     * Maximum number of simultaneous asynchronous requests
+     * in-flight awaiting resource (e.g. connection) availability
+     * before we reject additional requests.
+     */
+    default int getAsyncQueueLimit() {
+        return 1000;
+    }
+
+    /**
      * Timeout to establish initial connection.
      */
     default Duration getConnectTimeout() {

--- a/clientfactory-jersey/pom.xml
+++ b/clientfactory-jersey/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/clientfactory-resteasy/pom.xml
+++ b/clientfactory-resteasy/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-jaxrs-clientfactory-resteasy</artifactId>

--- a/clientfactory-testing/pom.xml
+++ b/clientfactory-testing/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-jaxrs-clientfactory-testing</artifactId>

--- a/exception/pom.xml
+++ b/exception/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-jaxrs-parent</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-jaxrs-exception</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-jaxrs-parent</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Allows you to configure e.g. submit 1000 ChatRequests asynchronously