### PR TITLE
clientfactory-resteasy: expose Apache HttpClientBuilder so we can reuse it for Twilio.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+otj-jaxrs changelog
+===================
+
+2.4.0
+-----
+
+jaxrs-clientfactory-resteasy: publicly expose Apache HttpClientBuilder for use by Twilio library

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/clientfactory-jersey/pom.xml
+++ b/clientfactory-jersey/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/clientfactory-resteasy/pom.xml
+++ b/clientfactory-resteasy/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-jaxrs-clientfactory-resteasy</artifactId>

--- a/clientfactory-testing/pom.xml
+++ b/clientfactory-testing/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-jaxrs-clientfactory-testing</artifactId>

--- a/exception/pom.xml
+++ b/exception/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.opentable.components</groupId>
     <artifactId>otj-jaxrs-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>otj-jaxrs-exception</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-jaxrs-parent</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>otj-jaxrs-parent</artifactId>
     <groupId>com.opentable.components</groupId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Twilio's `NetworkHttpClient` class allows you to instantiate it given a `HttpClientBuilder` so let's just reuse our existing logic.

Note that the build failure on Travis is expected for now, unfortunately, but I verified a snapshot deploy works ok locally.