### PR TITLE
Uses daemon threads in the executor service created by JaxRsClientFac…

### DIFF
--- a/clientfactory-resteasy/src/main/java/com/opentable/jaxrs/JaxRsClientFactoryImpl.java
+++ b/clientfactory-resteasy/src/main/java/com/opentable/jaxrs/JaxRsClientFactoryImpl.java
@@ -58,7 +58,7 @@ public class JaxRsClientFactoryImpl implements InternalClientFactory
     private void configureThreadPool(String clientName, ResteasyClientBuilder clientBuilder, JaxRsClientConfig config) {
         final ExecutorService executor = new ThreadPoolExecutor(8, 8, 1, TimeUnit.HOURS,
                 requestQueue(config.getAsyncQueueLimit()),
-                new ThreadFactoryBuilder().setNameFormat(clientName + "-worker-%s").build(),
+                new ThreadFactoryBuilder().setNameFormat(clientName + "-worker-%s").setDaemon(true).build(),
                 new ThreadPoolExecutor.AbortPolicy());
         clientBuilder.executorService(executor);
     }


### PR DESCRIPTION
…toryImpl.configureThreadPool

Fixes problem with thread pool not shutting down. The alternative would be to call asyncExecutor on the builder but that method has been executed.